### PR TITLE
CoreHandler is no longer a parent class to all the other Handlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ic4d",
-    "version": "4.0.0-beta.4",
+    "version": "4.0.0-beta.5",
     "description": "Discord.js Interaction and Command handler 4 Dummies",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/funcs.ts
+++ b/src/funcs.ts
@@ -47,34 +47,3 @@ export function getLocalCommands(
 
     return scanDirectory(path);
 }
-
-/**
- * Sets up a collector for message components with a specified timeout.
- *
- * @param client - The Discord client instance.
- * @param initInteraction - The initial interaction that triggered the setup.
- * @param interaction - An object containing the interaction details, including the onTimeout function, timeout duration, and customId.
- */
-export async function setupCollector(
-    client: Client,
-    initInteraction: ChatInputCommandInteraction,
-    interaction: InteractionBuilder
-) {
-    const { onTimeout, timeout, customId } = interaction;
-
-    const collector = initInteraction.channel.createMessageComponentCollector({
-        time: timeout,
-        filter: (i) => i.customId === customId,
-    });
-
-    collector.once("collect", (i) => {
-        // Handle the button click here or simply notify that it was clicked
-        // i.reply({ content: "Button was clicked!", ephemeral: true });
-        collector.stop("respondedInTime"); // Stop the collector after a click is detected. This is in a comment because when it's run it emits the "end" event.
-    });
-
-    collector.once("end", async (collected, reason) => {
-        if (reason !== "respondedInTime")
-            await onTimeout(initInteraction, client);
-    });
-}

--- a/src/handler/Errors.ts
+++ b/src/handler/Errors.ts
@@ -1,6 +1,6 @@
 import * as clc from "cli-color";
 
-class ic4dError extends Error {
+export class ic4dError extends Error {
     // throw new ic4dError("something", "msg", "file")
     fileName: string;
     constructor(

--- a/src/handler/commandHandler.ts
+++ b/src/handler/commandHandler.ts
@@ -14,7 +14,6 @@ import {
     LoaderOptions,
     RunFlags,
 } from "./interfaces";
-import { setupCollector } from "../funcs";
 
 /**
  * Helper function to just attach [DEV] to a command that is of developer.
@@ -421,12 +420,13 @@ export class CommandHandler {
                             "cHandler",
                             `addInteractionVaribles() has been called in the **${commandObject.name}** command`
                         );
-                        this.core.client.emit(
-                            HandlerVariables.Events.ADD_VARIABLE,
-                            interaction,
-                            commandObject,
-                            k
-                        );
+                        // this.core.client.emit(
+                        //     HandlerVariables.Events.ADD_VARIABLE,
+                        //     interaction,
+                        //     commandObject,
+                        //     k
+                        // );
+                        this.core.variables.add(interaction, commandObject, k);
                         return;
                     };
 
@@ -448,7 +448,7 @@ export class CommandHandler {
                                     value.timeout !== undefined
                             )
                             .forEach(async ([, value]) => {
-                                await setupCollector(
+                                await this.core.setupCollector(
                                     this.core.client,
                                     interaction,
                                     value
@@ -468,7 +468,7 @@ export class CommandHandler {
                                     value.timeout !== undefined
                             )
                             .forEach(async ([, value]) => {
-                                await setupCollector(
+                                await this.core.setupCollector(
                                     this.core.client,
                                     interaction,
                                     value

--- a/src/handler/coreHandler.ts
+++ b/src/handler/coreHandler.ts
@@ -194,7 +194,7 @@ export class CoreHandler extends EventEmitter {
         extender: Handlers,
         client: Client,
         debugMode = false,
-        logToFolder?: string | false
+        logToFolder: string | false = false
     ) {
         super();
         this.subClassName = extender;

--- a/src/handler/coreHandler.ts
+++ b/src/handler/coreHandler.ts
@@ -2,7 +2,6 @@ import {
     Client,
     ApplicationCommandManager,
     GuildApplicationCommandManager,
-    ApplicationCommandOptionType,
     ApplicationCommand,
     ChatInputCommandInteraction,
     ButtonInteraction,
@@ -18,7 +17,6 @@ import {
     ContextMenuObject,
     InteractionObject,
     HandlerVariables,
-    addInteractionVariables,
 } from "./interfaces";
 import {
     Interactions,
@@ -77,6 +75,11 @@ type cmd = {
 
 const isEmpty = (obj: Record<string, any>) => Object.keys(obj).length === 0;
 export type Handlers = "iHandler" | "cHandler" | "rHandler";
+
+/**
+ * Core handler class which is responsible for making every other handler class work
+ * Do not use any property in this class.
+ */
 export class CoreHandler extends EventEmitter {
     client: Client;
     v: Record<string, any> = {};
@@ -272,14 +275,14 @@ export class CoreHandler extends EventEmitter {
         },
     };
 
-    constructor(
-        client: Client,
-        debugMode = false,
-        logToFolder: string | false = false
-    ) {
+    /**
+     *
+     * @param client Discord.js Client Instance. (If you are sharding, rather enter the client instance into the other classes into the `shardClient` parameter and leave this undefined)
+     * @param logToFolder Default folder to log to.
+     */
+    constructor(client?: Client, logToFolder: string | false = false) {
         super();
         this.client = client;
-        this.coreFlags.debugger = debugMode || false;
         this.coreFlags.logToFolder = logToFolder || false;
     }
 

--- a/src/handler/interfaces.ts
+++ b/src/handler/interfaces.ts
@@ -18,15 +18,9 @@ import { Interactions } from "./builders/SlashCommandManager";
 export type addInteractionVariables = (k: { [key: string]: any }) => void;
 
 export namespace HandlerVariables {
-    export type Type = Record<string, any>;
-
     export enum Separators {
         INTERACTION_IDS = "~=~",
         DEFAULT = "~_~",
-    }
-
-    export enum Events {
-        ADD_VARIABLE = "interactionHandlerAddVariable",
     }
 }
 

--- a/src/handler/interfaces.ts
+++ b/src/handler/interfaces.ts
@@ -148,10 +148,9 @@ export interface HandlerFlags {
     debugger?: boolean;
     /**
      * When debugger mode is enabled, Either log to console or a file.
-     *
-     * When log to file specify a FOLDER path
+     * If this is not false, it will default to the folder in the CoreHandler instance.
      */
-    logToFile?: string | false;
+    logToFolder?: string | false;
     /**
      * Disabling Logging of the Command Loader. Not advised but hey it's your bot. Default is false.
      */
@@ -177,10 +176,9 @@ export interface InteractionHandlerFlags {
     debugger?: boolean;
     /**
      * When debugger mode is enabled, Either log to console or a file.
-     *
-     * When log to file specify a FOLDER path
+     * If this is not false, it will default to the folder in the CoreHandler instance.
      */
-    logToFile?: string | false;
+    logToFolder?: string | false;
     /**
      * Disabling Logging of the Context Menu Loader. Not advised but hey it's your bot. Default is false.
      */

--- a/src/handler/ready.ts
+++ b/src/handler/ready.ts
@@ -2,8 +2,8 @@ import { CoreHandler } from "./coreHandler";
 import { Client } from "discord.js";
 import clc = require("cli-color");
 
-export class ReadyHandler extends CoreHandler {
-    client: Client;
+export class ReadyHandler {
+    private core: CoreHandler;
     private emitErr: boolean = false;
     private functionsToRun: ((client?: Client) => Promise<void> | void)[] = [];
 
@@ -13,10 +13,10 @@ export class ReadyHandler extends CoreHandler {
      * @param functions Functions to be run when the bot is ready.
      */
     constructor(
-        client: Client,
+        core: CoreHandler,
         ...functions: ((client?: Client) => Promise<void> | void)[]
     ) {
-        super("rHandler", client);
+        this.core = core;
         this.functionsToRun = functions;
     }
 
@@ -32,10 +32,10 @@ export class ReadyHandler extends CoreHandler {
      * Run functions when the bot starts.
      */
     async execute() {
-        this.client.on("ready", async () => {
+        this.core.client.on("ready", async () => {
             for (const fn of this.functionsToRun) {
                 try {
-                    await fn(this.client);
+                    await fn(this.core.client);
                 } catch (error) {
                     let str = fn
                         .toString()

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export {
 } from "./handler/builders/builders";
 export { getLocalCommands } from "./funcs";
 export { RunFlags, HandlerFlags, LoaderOptions } from "./handler/interfaces";
+export { CoreHandler } from "./handler/coreHandler";


### PR DESCRIPTION
This update introduces a significant structural change: CoreHandler is no longer a parent class to the other handlers. Instead of extending CoreHandler, all handlers now take it as a property, passed explicitly as the first parameter in their constructors. This design improves modularity. To support this, the ReadyHandler constructor has also changed; the shard client must now be provided as the second parameter, after CoreHandler. If no shard client is being used, undefined must be passed explicitly. These changes enable each shard to work independently while maintaining clear communication between handlers through the CoreHandler instance. However, the update introduces breaking changes, as existing code must now be adjusted to account for the new constructor requirements.